### PR TITLE
Fix github links after moving the source code

### DIFF
--- a/audit/README.md
+++ b/audit/README.md
@@ -4,7 +4,7 @@
 ## Preamble
 This audit report was undertaken by <b>BlockchainLabs.nz</b> for the purpose of providing feedback to <b>Mothership</b>. <br>It has subsequently been shared publicly without any express or implied warranty.
 
-Solidity contracts were sourced from the public Github repo [consensus-ai/sen-contracts](hhttps://github.com/consensus-ai/sen-contracts) prior to commit [b2cd76f851f44f421530eb31ad85e33235a87355](https://github.com/BlockchainLabsNZ/mothership-sen/tree/b2cd76f851f44f421530eb31ad85e33235a87355) - we would encourage all community members and token holders to make their own assessment of the contracts.
+Solidity contracts were sourced from the public Github repo [consensus-ai/sen-contracts](https://github.com/consensus-ai/sen-contracts) prior to commit [b2cd76f851f44f421530eb31ad85e33235a87355](https://github.com/BlockchainLabsNZ/mothership-sen/tree/b2cd76f851f44f421530eb31ad85e33235a87355) - we would encourage all community members and token holders to make their own assessment of the contracts.
 
 <br>
 

--- a/audit/README.md
+++ b/audit/README.md
@@ -4,7 +4,7 @@
 ## Preamble
 This audit report was undertaken by <b>BlockchainLabs.nz</b> for the purpose of providing feedback to <b>Mothership</b>. <br>It has subsequently been shared publicly without any express or implied warranty.
 
-Solidity contracts were sourced from the public Github repo [mothershipcx/sen-contracts](hhttps://github.com/mothershipcx/sen-contracts) prior to commit [b2cd76f851f44f421530eb31ad85e33235a87355](https://github.com/BlockchainLabsNZ/mothership-sen/tree/b2cd76f851f44f421530eb31ad85e33235a87355) - we would encourage all community members and token holders to make their own assessment of the contracts.
+Solidity contracts were sourced from the public Github repo [consensus-ai/sen-contracts](hhttps://github.com/consensus-ai/sen-contracts) prior to commit [b2cd76f851f44f421530eb31ad85e33235a87355](https://github.com/BlockchainLabsNZ/mothership-sen/tree/b2cd76f851f44f421530eb31ad85e33235a87355) - we would encourage all community members and token holders to make their own assessment of the contracts.
 
 <br>
 
@@ -84,18 +84,18 @@ The audit report is focused on the following key areas - though this is not an e
 - **Use view or pure instead of constant modifier** - `Best practices`
 <br>MiniMeToken.sol, lines: [189](https://github.com/BlockchainLabsNZ/mothership-sen/blob/b2cd76f851f44f421530eb31ad85e33235a87355/contracts/MiniMeToken.sol#L189), [222](https://github.com/BlockchainLabsNZ/mothership-sen/blob/b2cd76f851f44f421530eb31ad85e33235a87355/contracts/MiniMeToken.sol#L222), [248](https://github.com/BlockchainLabsNZ/mothership-sen/blob/b2cd76f851f44f421530eb31ad85e33235a87355/contracts/MiniMeToken.sol#L248), [260](https://github.com/BlockchainLabsNZ/mothership-sen/blob/b2cd76f851f44f421530eb31ad85e33235a87355/contracts/MiniMeToken.sol#L260), ... [View on GitHub](https://github.com/BlockchainLabsNZ/mothership-sen/issues/5)
 
-  - [x] Fixed. [d70549](https://github.com/mothershipcx/sen-contracts/pull/3/commits/d70549db361b9a52cb8136fc77fb2c3e03c53182)
+  - [x] Fixed. [d70549](https://github.com/consensus-ai/sen-contracts/pull/3/commits/d70549db361b9a52cb8136fc77fb2c3e03c53182)
 
 - **Gas costs can be reduced by using bytes32 instead of string in proxyMintTokens()** - `Gas-optimization` <br>The `proxyMintTokens` function takes 2 parameters `string _paidCurrency, string _paidTxID`. It is possible to save on gas costs each time this function is called by changing these to `bytes32 _paidCurrency, bytes32 _paidTxID` ... 
 [View on GitHub](https://github.com/BlockchainLabsNZ/mothership-sen/issues/3)
 
-  - [x] Fixed. [PR4](https://github.com/mothershipcx/sen-contracts/pull/4)
+  - [x] Fixed. [PR4](https://github.com/consensus-ai/sen-contracts/pull/4)
 
 - **Favour require() over If() statements** - `Best practices`
 <br>it is better to keep the "require()" from the original MiniMeToken.sol ...
  [View on GitHub](https://github.com/BlockchainLabsNZ/mothership-sen/issues/1)
 
-  - [x] Fixed [125582](https://github.com/mothershipcx/sen-contracts/pull/3/commits/1255820c25742c9be924baf473ffb5bf1e0e9871)
+  - [x] Fixed [125582](https://github.com/consensus-ai/sen-contracts/pull/3/commits/1255820c25742c9be924baf473ffb5bf1e0e9871)
 
 ### Moderate
 - None found
@@ -135,7 +135,7 @@ The audit report is focused on the following key areas - though this is not an e
 
 The `controller` is able to transfer token balances to and from any account without permission. We recommend that once distribution of tokens has been finalized to call `changeController` to the 0x0 address so that there is a guarantee that balances cannot be altered in future by anyone.
 
-  - [x] Fixed. [3ac043](https://github.com/mothershipcx/sen-contracts/commit/3ac04396d3420974bfade80cdd4db419d3ac0ccf)
+  - [x] Fixed. [3ac043](https://github.com/consensus-ai/sen-contracts/commit/3ac04396d3420974bfade80cdd4db419d3ac0ccf)
 
 #### Controllership and token transfer
 


### PR DESCRIPTION
The source code was moved from https://github.com/mothershipcx/sen-contracts/